### PR TITLE
Cleanup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: A C library for the arithmetic of complex numbers with arbitrarily high
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/mpc-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/mpc-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/mpc-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/mpc-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/mpc-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/mpc-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/mpc/badges/version.svg)](https://anaconda.org/conda-forge/mpc)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/mpc/badges/downloads.svg)](https://anaconda.org/conda-forge/mpc)
+
 Installing mpc
 ==============
 
@@ -66,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/mpc-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/mpc-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/mpc-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/mpc-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/mpc-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/mpc-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/mpc/badges/version.svg)](https://anaconda.org/conda-forge/mpc)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/mpc/badges/downloads.svg)](https://anaconda.org/conda-forge/mpc)
 
 
 Updating mpc-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ environment:
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
-  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -23,6 +23,10 @@ for %%d in (mpir, mpfr) do (
 REM copy headers
 xcopy %LIBRARY_INC%\*.h mpir\lib\%PLATFORM%\Release\ /E
 xcopy %LIBRARY_INC%\*.h mpir\dll\%PLATFORM%\Release\ /E
+copy %LIBRARY_INC%\gmp-config.h mpir\lib\%PLATFORM%\Release\config.h
+copy %LIBRARY_INC%\gmp-config.h mpir\dll\%PLATFORM%\Release\config.h
+copy %LIBRARY_INC%\gmp-longlong.h mpir\lib\%PLATFORM%\Release\longlong.h
+copy %LIBRARY_INC%\gmp-longlong.h mpir\dll\%PLATFORM%\Release\longlong.h
 
 cd %mpc_root%\build.vc14
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-if [ "$(uname)" == "Darwin" ];
-then
-    export CC=clang
-    export CXX=clang++
-
-    export MACOSX_VERSION_MIN=10.7
-    export CXXFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -std=c++11"
-    export LINKFLAGS="-mmacosx-version-min=${MACOSX_VERSION_MIN}"
-    export LINKFLAGS="${LINKFLAGS} -stdlib=libc++ -std=c++11 -L${LIBRARY_PATH}"
-fi
-
 export LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
 
 ./configure --prefix=$PREFIX \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,7 +48,7 @@ test:
 about:
   home: http://www.multiprecision.org/
   license: LGPL 3
-  license_file: COPYING.LESSER
+  license_file: {{ SRC_DIR }}/COPYING.LESSER
   summary: A C library for the arithmetic of complex numbers with arbitrarily high precision.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,6 +21,7 @@ build:
 
 requirements:
   build:
+    - toolchain
     - python          # [win]
     - m4              # [unix]
     - libtool         # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ test:
 about:
   home: http://www.multiprecision.org/
   license: LGPL 3
-  license: COPYING.LESSER
+  license_file: COPYING.LESSER
   summary: A C library for the arithmetic of complex numbers with arbitrarily high precision.
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   md5: a3ccbbb17770110427a983638824f31b                                     # [win]
 
 build:
-  number: 2
+  number: 3
   skip: true          # [win and not py35]
   features:
     - vc14            # [win and py35]


### PR DESCRIPTION
Closes https://github.com/conda-forge/mpc-feedstock/pull/6

* Fixes the license metadata.
* Uses the toolchain.
* Re-renders with conda-smithy 1.6.1
* Bumps the build number.

cc @isuruf